### PR TITLE
Better representation of `MetaConfig` objects as a tree

### DIFF
--- a/src/metaconf/config.py
+++ b/src/metaconf/config.py
@@ -3,7 +3,7 @@ import json
 import logging
 from os import PathLike
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Iterator, Self
 
 from .node import Node, path_to_node, to_node
 from .utils import switch_dir
@@ -57,26 +57,55 @@ class MetaConfig:
 
                 handler.write(config.path, data[field.name], overwrite_ok=overwrite_ok)
 
-    def tree(self, level: int = 1, print_: bool = True) -> list[str]:
-        elbow = "└──"
+    def nodes(self, recurse: bool = False) -> Iterator[Node]:
+        for field in dataclasses.fields(self):
+            node = getattr(self, field.name)
+
+            yield node
+
+            if recurse and isinstance(handler := node.handler(), MetaConfig):
+                yield from handler.nodes()
+
+    def _tree(
+        self, prefix: str, depth: int, max_depth: int | None, details: bool
+    ) -> Iterator[str]:
+        blank = "   "
         pipe = "│  "
         tee = "├──"
-        blank = "   "
-        lines = []
+        elbow = "└──"
+
         fields = dataclasses.fields(self)
-        for i, f in enumerate(fields):
-            config = getattr(self, f.name)
+        pointers = [tee] * (len(fields) - 1) + [elbow]
+        longest_name = max([len(field.name) for field in fields])
+
+        for pointer, field in zip(pointers, fields):
+            config = getattr(self, field.name)
             handler = config.handler()
 
-            lines += [level * pipe + (elbow if i == len(fields) else tee) + config.path]
+            if details:
+                separator = " " + "-" * (longest_name + 4 - len(field.name)) + " "
+                node_repr = f"(path='{config.path}', handler={type(handler).__name__})"
+            else:
+                separator, node_repr = "", ""
 
-            if isinstance(handler, MetaConfig):
-                lines += handler.tree(level=level + 1, print_=False)
+            yield prefix + pointer + field.name + separator + node_repr
 
-        if print_:
-            print("\n".join(lines))
+            if depth < (max_depth or depth + 1) and isinstance(handler, MetaConfig):
+                extension = pipe if pointer == tee else blank
+                yield from handler._tree(
+                    prefix=prefix + extension,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    details=details,
+                )
 
-        return lines
+    def tree(self, max_depth: int | None = None, details: bool = True) -> str:
+        return "\n".join(
+            list(self._tree(prefix="", depth=1, max_depth=max_depth, details=details))
+        )
+
+    def __str__(self) -> str:
+        return f"{type(self).__module__}.{type(self).__name__}\n{self.tree()}"
 
 
 def _make_metaconfig(cls_name: str, config: dict, **kwargs) -> type[MetaConfig]:


### PR DESCRIPTION
Inspired by the GNU `tree` command, but since I want to support nodes having absolute paths to locations outside of the config dir (e.g. large shared data files expected to be present but not necessarily in the config directory), I opted to make a tree based on the field names, with paths and handlers given as extra details.

This is an example from https://github.com/NERC-CEH/jules-tools. 

```python
❯ print(jules_config_handler)
metaconf.config.JulesDirectoryConfig
├──namelists ---- (path='namelists', handler=NamelistFilesConfig)
│  ├──ancillaries -------------- (path='ancillaries.nml', handler=NamelistFileHandler)
│  ├──crop_params -------------- (path='crop_params.nml', handler=NamelistFileHandler)
│  ├──drive -------------------- (path='drive.nml', handler=NamelistFileHandler)
│  ├──fire --------------------- (path='fire.nml', handler=NamelistFileHandler)
│  ├──imogen ------------------- (path='imogen.nml', handler=NamelistFileHandler)
│  ├──initial_conditions ------- (path='initial_conditions.nml', handler=NamelistFileHandler)
│  ├──jules_deposition --------- (path='jules_deposition.nml', handler=NamelistFileHandler)
│  ├──jules_hydrology ---------- (path='jules_hydrology.nml', handler=NamelistFileHandler)
│  ├──jules_irrig -------------- (path='jules_irrig.nml', handler=NamelistFileHandler)
│  ├──jules_prnt_control ------- (path='jules_prnt_control.nml', handler=NamelistFileHandler)
│  ├──jules_radiation ---------- (path='jules_radiation.nml', handler=NamelistFileHandler)
│  ├──jules_rivers ------------- (path='jules_rivers.nml', handler=NamelistFileHandler)
│  ├──jules_snow --------------- (path='jules_snow.nml', handler=NamelistFileHandler)
│  ├──jules_soil_biogeochem ---- (path='jules_soil_biogeochem.nml', handler=NamelistFileHandler)
│  ├──jules_soil --------------- (path='jules_soil.nml', handler=NamelistFileHandler)
│  ├──jules_surface ------------ (path='jules_surface.nml', handler=NamelistFileHandler)
│  ├──jules_surface_types ------ (path='jules_surface_types.nml', handler=NamelistFileHandler)
│  ├──jules_vegetation --------- (path='jules_vegetation.nml', handler=NamelistFileHandler)
│  ├──jules_water_resources ---- (path='jules_water_resources.nml', handler=NamelistFileHandler)
│  ├──model_environment -------- (path='model_environment.nml', handler=NamelistFileHandler)
│  ├──model_grid --------------- (path='model_grid.nml', handler=NamelistFileHandler)
│  ├──nveg_params -------------- (path='nveg_params.nml', handler=NamelistFileHandler)
│  ├──output ------------------- (path='output.nml', handler=NamelistFileHandler)
│  ├──pft_params --------------- (path='pft_params.nml', handler=NamelistFileHandler)
│  ├──prescribed_data ---------- (path='prescribed_data.nml', handler=NamelistFileHandler)
│  ├──science_fixes ------------ (path='science_fixes.nml', handler=NamelistFileHandler)
│  ├──timesteps ---------------- (path='timesteps.nml', handler=NamelistFileHandler)
│  ├──triffid_params ----------- (path='triffid_params.nml', handler=NamelistFileHandler)
│  └──urban -------------------- (path='urban.nml', handler=NamelistFileHandler)
└──inputs ------- (path='inputs', handler=InputFilesConfig)
   ├──initial_conditions ---- (path='initial_conditions_bb219.dat', handler=AsciiFileHandler)
   ├──driving_data ---------- (path='Loobos_1997.dat', handler=AsciiFileHandler)
   └──tile_fractions -------- (path='tile_fractions.dat', handler=AsciiFileHandler)
```